### PR TITLE
解決line無法登入問題

### DIFF
--- a/db/migrate/20230523004845_remove_unique_constraint_from_email_in_users.rb
+++ b/db/migrate/20230523004845_remove_unique_constraint_from_email_in_users.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueConstraintFromEmailInUsers < ActiveRecord::Migration[6.1]
+  def change
+    change_column :users, :email, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_20_060429) do
+ActiveRecord::Schema.define(version: 2023_05_23_004845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,7 +162,7 @@ ActiveRecord::Schema.define(version: 2023_05_20_060429) do
     t.string "address"
     t.string "avatar_url"
     t.string "provider"
-    t.string "email", default: "", null: false
+    t.string "email", default: ""
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"


### PR DESCRIPTION
之前在建立email欄位的時候有設定unique: true, 欄位不可重複
但line登入後不會回傳email, 所以如果有人登入過了，但資料庫會有一筆空值, 第二個人再登入又是一筆空值就重複了, 會登入失敗

暫時先修改欄位為可重複, 可以解決這問題 （可能不是好的解決辦法？）